### PR TITLE
V13.20250422 Ny styrelse 2025

### DIFF
--- a/src/foreningen/organisation/index.php
+++ b/src/foreningen/organisation/index.php
@@ -2,7 +2,7 @@
   $header_title = "Organisation - Föreningen";
   $header_description = "Vår ideella förenings organisationsträd";
 
-  $page_updated = "2025-03-10 18:03";
+  $page_updated = "2025-04-22 19:29";
   $page_url = "/foreningen/organisation";
   $page_contact_name = "Styrelsen";
   $page_contact_email = "styrelsen@rockrullarna.se";
@@ -38,6 +38,11 @@
           <tr>
             <td>
               <p><strong>► <a href="./valberedningen" title="Valberedningen">Valberedningen</a></strong></p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p><strong>► <a href="./revisorer" title="Revisorer">Revisorer</a></strong></p>
             </td>
           </tr>
         </tbody>

--- a/src/foreningen/organisation/revisorer/index.php
+++ b/src/foreningen/organisation/revisorer/index.php
@@ -1,0 +1,45 @@
+<?php
+  $header_title = "Revisorer - Organisation - Föreningen";
+  $header_description = "Information om den ideella föreningens valberedning";
+
+  $page_updated = "2025-04-22 19:10";
+  $page_url = "/foreningen/organisation/revisorer";
+  $page_contact_name = "Revisorerna";
+  $page_contact_email = "ekonomi@rockrullarna.se";
+
+  include_once '../../../includes/header.php'
+?>
+    <div id="BreadCrumbsDiv">
+      <a href="../../../">Rockrullarna.se</a> / <a href="../../">Föreningen</a> / <a href="../">Organisation</a> / <span>Revisorer</span>
+    </div>
+    <h1>
+      Revisorer
+    </h1>
+    <p>Revisorernas uppgift är att årligen granska föreningens räkenskaper och förvaltning. Revisorerna ska vara oberoende av dem som de har att granska.</p>
+    <p>Revisorerna har rätt att fortlöpande ta del av föreningens räkenskaper, årsmötes- och styrelseprotokoll och övriga handlingar som kan tänkas behövas för revisionen.</p>
+    <p>Föreningens räkenskaper för det senaste verksamhets- och räkenskapsåret ska vara revisorerna tillhanda <b>senast en månad</b> före årsmötet.</p>
+    <p>Revisorerna ska granska styrelsens förvaltning och räkenskaper för det senaste verksamhets- och räkenskapsåret samt till styrelsen överlämna revisionsberättelse senast 14 dagar före årsmötet.</p>
+    <p>Revisorerna ska även granska att styrelsen följer föreningens stadgar och de beslut som årsmötet fattat.</p>
+    <p>&nbsp;</p>
+    <h2>
+      Revisorerna 2025-2026
+    </h2>
+    <p>Revisorerna för mars 2025 - mars 2026 består av:</p>
+    <ul>
+      <li>Revisor (1 år) Karl-Erik Wallin</li>
+      <li>Revisor (1 år) Kjell Englund</li>
+      <li>Revisor ersättare (1 år) Andreas "Brunte" Espeborn</li>
+      <li>Revisor ersättare (1 år) Jonas Stenström</li>
+    </ul>
+    <p>&nbsp;</p>
+    <hr />
+    <h2>
+      Kontakt med revisorerna?
+    </h2>
+    <p>Vill du komma i kontakt med våra revisorer? Skicka då ett mejl till:</p>
+    <p>► <a href="mailto:ekonomi@rockrullarna.se" title="Mejla till: ekonomi@rockrullarna.se">ekonomi@rockrullarna.se</a></p>
+    <p>► <a href="mailto:styrelsen@rockrullarna.se" title="Mejla till: styrelsen@rockrullarna.se">styrelsen@rockrullarna.se</a></p>
+    <p><em>så hjälper vi dig att komma i kontakt med våra revisorer.</em></p>
+<?php
+  include_once '../../../includes/footer.php'
+?>

--- a/src/foreningen/organisation/strukturen/index.php
+++ b/src/foreningen/organisation/strukturen/index.php
@@ -2,7 +2,7 @@
 $header_title = "Styrelsen - Organisation - Organisationsstruktur";
 $header_description = "Information om den ideella dansföreningen Rockrullarnas styrelse";
 
-$page_updated = "2025-03-10 18:10";
+$page_updated = "2025-04-22 19:20";
 $page_url = "/foreningen/organisation/styrelsen";
 $page_contact_name = "Styrelsen";
 $page_contact_email = "styrelsen@rockrullarna.se";
@@ -219,7 +219,6 @@ include_once '../../../includes/header.php'
     <li>Jens Wiklund (Fox)</li>
     <li>Jonas Arvidson (Fox/WCS)</li>
   </ul>
-  <p>Nellie Modin, Stefan Ericsson, Jonas Arvidson.</p>
   <h3 id="kursadministrations-kommitteen">Kursadministrationskommittén</h3>
   <ul>
     <li>Thomas Modin (Bugg)</li>
@@ -231,6 +230,7 @@ include_once '../../../includes/header.php'
   <ul>
     <li>Thomas Modin (Bugg)</li>
     <li>Ulrika Aronsson (Fox)</li>
+    <li>David Filblad (Fox)</li>
     <li>Maria R Holm (WCS)</li>
   </ul>
   <h3 id="musik-kommitteen">Musikkommittén</h3>

--- a/src/foreningen/organisation/styrelsen/index.php
+++ b/src/foreningen/organisation/styrelsen/index.php
@@ -2,7 +2,7 @@
   $header_title = "Styrelsen - Organisation - Föreningen";
   $header_description = "Information om den ideella dansföreningen Rockrullarnas styrelse";
 
-  $page_updated = "2024-04-01 20:34";
+  $page_updated = "2025-04-22 19:04";
   $page_url = "/foreningen/organisation/styrelsen";
   $page_contact_name = "Styrelsen";
   $page_contact_email = "styrelsen@rockrullarna.se";
@@ -15,19 +15,21 @@
     <h1>
       Styrelsen
     </h1>
-    <p><strong>Det är vi som sitter i styrelsen sedan årsmötet 2024-03-23.</strong></p>
+    <p><strong>Det är vi som sitter i styrelsen sedan årsmötet 2025-03-29.</strong></p>
     <p>
-      Ordförande (2 år): John Hägglöf<br />
+      Ordförande (1 år fyllnadsval): Petra Johansson<br />
       Vice ordförande (1 år): inte vald än<br />
-      Kassör (2 år):  Helena Luthman<br />
+      Kassör (1 år fyllnadsval): Annica Kindborg <br />
       Sekreterare: Utlyses separat per styrelsemöte<br />
-      Ledamot (2 år): Elin Östlund<br />
-      Ledamot (1 år): Pernilla Söderqvist<br />
-      Ledamot (1 år): Peter Århammar<br />
-      Ledamot (1 år): Petra Johansson<br />
-      Ledamot (1 år): Emil Schyman<br />
-      Suppleant (1 år): Andreas Milton<br />
-      Suppleant (1 år): Åsa Nilsson
+      Ledamot (2 år): Stefan Ericsson<br />
+      Ledamot (2 år): Mathias Grundblad<br />
+      Ledamot (2 år): Emil Schyman<br />
+      Ledamot (1 år fyllnadsval): Linnea Sohlberg Modin<br />
+      Ledamot (1 år fyllnadsval): Camilla Wellsén<br />
+      Suppleant (1 år): Maria Carneland<br />
+      Suppleant (1 år): Pernilla Söderqvist<br />
+      Suppleant (1 år): Emma Söderström Arnell<br />
+      Suppleant (1 år): Daniel Hjalmarsson<br /><br />
     </p>
     <p>
       <em>

--- a/src/foreningen/organisation/tidigare-styrelser/index.php
+++ b/src/foreningen/organisation/tidigare-styrelser/index.php
@@ -2,7 +2,7 @@
   $header_title = "Tidigare styrelser - Organisation - Föreningen";
   $header_description = "Information om den ideella föreningens tidigare styrelser";
 
-  $page_updated = "2023-05-02 20:25";
+  $page_updated = "2025-04-22 19:08";
   $page_url = "/foreningen/organisation/tidigare-styrelser";
   $page_contact_name = "Styrelsen";
   $page_contact_email = "styrelsen@rockrullarna.se";
@@ -17,6 +17,32 @@
     </h1>
     <p>
       Styrelser från tidigare år
+    </p>
+    <p>
+      <strong>Styrelsen från årsmötet 2024-03-23</strong><br />
+      Ordförande (2 år): John Hägglöf<br />
+      Vice ordförande (1 år): inte vald än<br />
+      Kassör (2 år):  Helena Luthman<br />
+      Sekreterare: Utlyses separat per styrelsemöte<br />
+      Ledamot (2 år): Elin Östlund<br />
+      Ledamot (1 år): Pernilla Söderqvist<br />
+      Ledamot (1 år): Peter Århammar<br />
+      Ledamot (1 år): Petra Johansson<br />
+      Ledamot (1 år): Emil Schyman<br />
+      Suppleant (1 år): Andreas Milton<br />
+      Suppleant (1 år): Åsa Nilsson<br /><br />
+    </p>
+    <p>
+      <strong>Styrelsen från årsmötet 2023-03-25</strong><br />
+      Ordförande (1år): John Hägglöf<br />
+      Vice ordförande (2år): Pierre Hagström (vakant, hoppat av sitt uppdrag)<br />
+      Kassör (1år): Jonas Arvidson<br />
+      Ledamot (2år): Pernilla Söderqvist<br />
+      Ledamot (2år): Peter Århammar<br />
+      Ledamot (2år): Marie Hedlund<br />
+      Ledamot (1år): Jenny Öhman<br />
+      Suppleant (1år): Andreas Milton<br />
+      Suppleant (1år): Åke Eriksson<br /><br />
     </p>
     <p>
       <strong>Styrelsen från årsmötet 2022</strong><br />

--- a/src/foreningen/organisation/valberedningen/index.php
+++ b/src/foreningen/organisation/valberedningen/index.php
@@ -2,7 +2,7 @@
   $header_title = "Valberedningen - Organisation - Föreningen";
   $header_description = "Information om den ideella föreningens valberedning";
 
-  $page_updated = "2022-12-30 00:24";
+  $page_updated = "2025-04-22 19:09";
   $page_url = "/foreningen/organisation/valberedningen";
   $page_contact_name = "Valberedningen";
   $page_contact_email = "valberedningen@rockrullarna.se";
@@ -18,12 +18,12 @@
     <p>Valberednings arbetsuppgift är att ge förslag till revisorer och ledamöter till styrelsen. Som representant i valberedningen förväntas du ha god kunskap om verksamheten samt kännedom om de personer som är aktiva i föreningen.</p>
     <p>Valberedningen är fristående från styrelsen, ska kontinuerligt följa verksamheten och söka efter personer som tillsammans utger en bra representation av föreningens medlemmar.</p>
     <p>&nbsp;</p>
-    <h2>Valberedningen 2024-2025</h2>
-    <p>Valberedningen för mars 2024 - mars 2025 består av:</p>
+    <h2>Valberedningen 2025-2026</h2>
+    <p>Valberedningen för mars 2025 - mars 2026 består av:</p>
     <ul>
-      <li>Sofia Olsen</li>
-      <li>Anders Nilsson</li>
-      <li>Joakim Berg</li>
+      <li>Andreas Milton</li>
+      <li>???</li>
+      <li>???</li>
     </ul>
     <p>&nbsp;</p>
     <hr />

--- a/src/foreningen/styrande-dokument/stadgar/index.php
+++ b/src/foreningen/styrande-dokument/stadgar/index.php
@@ -2,7 +2,7 @@
   $header_title = "Stadgar - Styrande dokument - Föreningen";
   $header_description = "Vår ideella förenings nuvarande stadgar";
 
-  $page_updated = "2022-06-14 23:33";
+  $page_updated = "2025-03-29 17:00";
   $page_url = "/foreningen/styrande-dokument/stadgar";
   $page_contact_name = "Styrelsen";
   $page_contact_email = "styrelsen@rockrullarna.se";
@@ -222,7 +222,7 @@
     <li>Val av<ol style="list-style-type: lower-alpha;">
     <li>föreningens ordförande för en tid av två (2) år (jämna år);</li>
     <li>tre (3) ledamöter i styrelsen för en tid av två (2) år;</li>
-    <li>två (2) suppleanter (ersättare) i styrelsen för en tid av ett (1) år;</li>
+    <li>två (2) till fyra (4) suppleanter (ersättare) i styrelsen för en tid av ett (1) år;</li>
     <li>två (2) revisorer jämte suppleanter (ersättare) för en tid av ett (1) år. I detta val får inte styrelsens ledamöter delta;</li>
     <li>tre (3) ledamöter i valberedningen för en tid av ett (1) år, av vilka en ska utses till ordförande.</li>
     </ol></li>

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -234,6 +234,7 @@
                     <li><a class="dropdown-item" href="https://rockrullarna.se/foreningen/organisation/tidigare-styrelser">Tidigare styrelser</a></li>
                     <li><hr class="dropdown-divider"></li>
                     <li><a class="dropdown-item" href="https://rockrullarna.se/foreningen/organisation/valberedningen">Valberedningen</a></li>
+                    <li><a class="dropdown-item" href="https://rockrullarna.se/foreningen/organisation/revisorer">Revisorer</a></li>
                   </ul>
                 </li>
                 <li><a class="dropdown-item" href="https://rockrullarna.se/foreningen/medlemsrabatter">Medlemsrabatter</a></li>

--- a/src/webbkarta/index.php
+++ b/src/webbkarta/index.php
@@ -2,7 +2,7 @@
   $header_title = "Webbkarta";
   $header_description = "Webbkarta (sitemap) för webbsidan: rockrullarna.se";
 
-  $page_updated = "2025-01-06 23:55";
+  $page_updated = "2025-04-22 19:27";
   $page_url = "/webbkarta";
   $page_contact_name = "Info";
   $page_contact_email = "info@rockrullarna.se";
@@ -70,9 +70,11 @@
             </li>
             <li class="dropdown"><a href="/foreningen/organisation" title="Organisation">Organisation</a>
               <ul>
+              <li><a href="/foreningen/organisation/strukturen" title="Strukturen">Strukturen</a></li>
                 <li><a href="/foreningen/organisation/styrelsen" title="Styrelsen">Styrelsen</a></li>
                 <li><a href="/foreningen/organisation/tidigare-styrelser" title="Tidigare styrelser">Tidigare styrelser</a></li>
                 <li><a href="/foreningen/organisation/valberedningen" title="Valberedningen">Valberedningen</a></li>
+                <li><a href="/foreningen/organisation/revisorer" title="Revisorer">Revisorer</a></li>
               </ul>
             </li>
             <li><a href="/foreningen/medlemsrabatter" title="Medlemsrabatter">Medlemsrabatter</a></li>


### PR DESCRIPTION
This pull request introduces several updates to the organization's website, including the addition of a new section for auditors ("Revisorer"), updates to organizational pages for the current year, and structural changes to the site navigation and sitemap. Below are the most important changes grouped by theme:

### New Section: Auditors ("Revisorer")
* Added a new page `src/foreningen/organisation/revisorer/index.php` with detailed information about the auditors' roles, responsibilities, and contact details.
* Included a link to the new "Revisorer" section in the organization page (`src/foreningen/organisation/index.php`) and the main navigation menu (`src/includes/header.php`). [[1]](diffhunk://#diff-f33075865025127fde6c20bb66e9a6cd714bec41e7c76d55151f527402474c3dR43-R47) [[2]](diffhunk://#diff-5950c1e0ac439a244ded5bfdb12fc03fe43b42c96fc7f49b79e6fe98fdffaff8R237)
* Updated the sitemap to reflect the addition of the "Revisorer" section.

### Updates to Organizational Pages
* Updated the "Styrelsen" (Board) page with the latest board members for 2025-2026, reflecting changes from the most recent annual meeting.
* Revised the "Valberedningen" (Nomination Committee) and "Tidigare Styrelser" (Previous Boards) pages to include updated information for the current and past years. [[1]](diffhunk://#diff-4dcf4303ffad9f041ee81507ebd29ac144cfff6465274ad40c8b516458b0ea41L21-R26) [[2]](diffhunk://#diff-cc046249ce9d0a51016586cc4b1a9450573124b08e0f5728404f2494cab624b4R21-R46)

### Structural and Content Updates
* Adjusted the organization's bylaws to allow for two to four board alternates instead of a fixed number of two.
* Updated the "Strukturen" (Structure) page to add a new member to the "Kursadministrationskommittén" (Course Administration Committee).

### General Metadata Updates
* Updated the `page_updated` metadata across multiple files to reflect the latest modification date of April 22, 2025. [[1]](diffhunk://#diff-f33075865025127fde6c20bb66e9a6cd714bec41e7c76d55151f527402474c3dL5-R5) [[2]](diffhunk://#diff-8b1414e1fc5c23aa3d41206a61a75ce978b1f63cd20139699de59f59247daa77L5-R5) [[3]](diffhunk://#diff-e8da500e12c086d6892609c1958cd012f71ceaa0c54c6ddd74afa68d33264429L5-R5) [[4]](diffhunk://#diff-cc046249ce9d0a51016586cc4b1a9450573124b08e0f5728404f2494cab624b4L5-R5) [[5]](diffhunk://#diff-4dcf4303ffad9f041ee81507ebd29ac144cfff6465274ad40c8b516458b0ea41L5-R5) [[6]](diffhunk://#diff-93a24373735a351847a88229d19cfa80d9cfc512d2926e0f09670e0dc17fc4faL5-R5) [[7]](diffhunk://#diff-ced6ecc258b564ba0996277b04d9ca717bbcf5a3a1ab6ded140578e4264fb1e1L5-R5)