### PR TITLE
Add link to marketing materials on logotype page

### DIFF
--- a/src/logotyp/index.php
+++ b/src/logotyp/index.php
@@ -252,6 +252,7 @@
     </table>
   </div>
   <p id="filterResultInfo" class="text-muted small"></p>
+  <p> Det finns även marknadsföringsmaterial tillgängligt via: <a href="/marknadsforing/">https://www.Rockrullarna.se/marknadsforing</a></p>
   <script>
     (function() {
       const select = document.getElementById('gallerychildalbum');


### PR DESCRIPTION
This pull request adds a small update to the `src/logotyp/index.php` file. The change introduces a new paragraph with a link to available marketing materials for users.

* Added a paragraph with a link to the marketing materials page (`/marknadsforing/`) to inform users about additional resources.