### PR TITLE
Uppdaterat till korrekt kapitel-avsnitt-underavsnitt indelning

### DIFF
--- a/src/foreningen/styrande-dokument/dkrr-001-verksamhetsbeskrivning/index.php
+++ b/src/foreningen/styrande-dokument/dkrr-001-verksamhetsbeskrivning/index.php
@@ -839,43 +839,43 @@
           <h3 class="scrollspy-heading">Innehållsförteckning</h3>
           <nav class="nav nav-pills flex-column">
             <a class="nav-link" href="#kap1">1 Inledning</a>
-            <a class="nav-link section" href="#kap1-1">1.1 Bakgrund</a>
-            <a class="nav-link section" href="#kap1-2">1.2 Syfte</a>
-            <a class="nav-link section" href="#kap1-3">1.3 Versionshistorik</a>
+            <a class="nav-link avsnitt" href="#kap1-1">1.1 Bakgrund</a>
+            <a class="nav-link avsnitt" href="#kap1-2">1.2 Syfte</a>
+            <a class="nav-link avsnitt" href="#kap1-3">1.3 Versionshistorik</a>
             <a class="nav-link" href="#kap2">2 Verksamhetsmål</a>
             <a class="nav-link" href="#kap3">3 Styrande dokument</a>
             <a class="nav-link" href="#kap4">4 Kontakt och aktivitetsinformation</a>
-            <a class="nav-link section" href="#kap4-1">4.1 Kontakt</a>
-            <a class="nav-link section" href="#kap4-2">4.2 Besöksadress</a>
-            <a class="nav-link section" href="#kap4-3">4.3 Hemsida</a>
-            <a class="nav-link section" href="#kap4-4">4.4 Intranät</a>
-            <a class="nav-link section" href="#kap4-5">4.5 Sociala medier</a>
+            <a class="nav-link avsnitt" href="#kap4-1">4.1 Kontakt</a>
+            <a class="nav-link avsnitt" href="#kap4-2">4.2 Besöksadress</a>
+            <a class="nav-link avsnitt" href="#kap4-3">4.3 Hemsida</a>
+            <a class="nav-link avsnitt" href="#kap4-4">4.4 Intranät</a>
+            <a class="nav-link avsnitt" href="#kap4-5">4.5 Sociala medier</a>
             <a class="nav-link" href="#kap5">5 Lokal</a>
-            <a class="nav-link section" href="#kap5-1">5.1 Säkerhetsinformation</a>
-            <a class="nav-link section" href="#kap5-2">5.2 Tillträde</a>
-            <a class="nav-link section" href="#kap5-3">5.3 Hyra av lokal för kommersiellt bruk</a>
-            <a class="nav-link section" href="#kap5-4">5.4 Bokning av Lilla salen</a>
-            <a class="nav-link section" href="#kap5-5">5.5 Nyttjande av lokal för barnkalas</a>
-            <a class="nav-link section" href="#kap5-6">5.6 Nyttjande av lokal för privat bruk</a>
+            <a class="nav-link avsnitt" href="#kap5-1">5.1 Säkerhetsinformation</a>
+            <a class="nav-link avsnitt" href="#kap5-2">5.2 Tillträde</a>
+            <a class="nav-link avsnitt" href="#kap5-3">5.3 Hyra av lokal för kommersiellt bruk</a>
+            <a class="nav-link avsnitt" href="#kap5-4">5.4 Bokning av Lilla salen</a>
+            <a class="nav-link avsnitt" href="#kap5-5">5.5 Nyttjande av lokal för barnkalas</a>
+            <a class="nav-link avsnitt" href="#kap5-6">5.6 Nyttjande av lokal för privat bruk</a>
             <a class="nav-link" href="#kap6">6 Trivselregler</a>
             <a class="nav-link" href="#kap7">7 Utbud (danskurser/evenemang/aktiviteter)</a>
-            <a class="nav-link section" href="#kap7-1">7.1 Bugg</a>
-            <a class="nav-link section" href="#kap7-2">7.2 West Coast Swing</a>
-            <a class="nav-link section" href="#kap7-3">7.3 Fox</a>
-            <a class="nav-link section" href="#kap7-4">7.4 Dans för barn och ungdom</a>
-            <a class="nav-link section" href="#kap7-5">7.5 Fri träning</a>
-            <a class="nav-link section" href="#kap7-6">7.6 Evenemang utanför ordinarie verksamhet</a>
-            <a class="nav-link section" href="#kap7-7">7.7 Träningskväll</a>
-            <a class="nav-link section" href="#kap7-8">7.8 Socialdanskväll</a>
-            <a class="nav-link section" href="#kap7-9">7.9 Medlemsmöte</a>
-            <a class="nav-link section" href="#kap7-10">7.10 Årsmöte</a>
-            <a class="nav-link section" href="#kap7-11">7.11 Externa kurser</a>
-            <a class="nav-link section" href="#kap7-12">7.12 Privatlektioner</a>
-            <a class="nav-link section" href="#kap7-13">7.13 Uppvisning</a>
+            <a class="nav-link avsnitt" href="#kap7-1">7.1 Bugg</a>
+            <a class="nav-link avsnitt" href="#kap7-2">7.2 West Coast Swing</a>
+            <a class="nav-link avsnitt" href="#kap7-3">7.3 Fox</a>
+            <a class="nav-link avsnitt" href="#kap7-4">7.4 Dans för barn och ungdom</a>
+            <a class="nav-link avsnitt" href="#kap7-5">7.5 Fri träning</a>
+            <a class="nav-link avsnitt" href="#kap7-6">7.6 Evenemang utanför ordinarie verksamhet</a>
+            <a class="nav-link avsnitt" href="#kap7-7">7.7 Träningskväll</a>
+            <a class="nav-link avsnitt" href="#kap7-8">7.8 Socialdanskväll</a>
+            <a class="nav-link avsnitt" href="#kap7-9">7.9 Medlemsmöte</a>
+            <a class="nav-link avsnitt" href="#kap7-10">7.10 Årsmöte</a>
+            <a class="nav-link avsnitt" href="#kap7-11">7.11 Externa kurser</a>
+            <a class="nav-link avsnitt" href="#kap7-12">7.12 Privatlektioner</a>
+            <a class="nav-link avsnitt" href="#kap7-13">7.13 Uppvisning</a>
             <a class="nav-link" href="#kap8">8 Anmälan och betalning</a>
-            <a class="nav-link section" href="#kap8-1">8.1 Anmälan</a>
-            <a class="nav-link section" href="#kap8-2">8.2 Betalning</a>
-            <a class="nav-link section" href="#kap8-3">8.3 Inställd kurs och återbetalning</a>
+            <a class="nav-link avsnitt" href="#kap8-1">8.1 Anmälan</a>
+            <a class="nav-link avsnitt" href="#kap8-2">8.2 Betalning</a>
+            <a class="nav-link avsnitt" href="#kap8-3">8.3 Inställd kurs och återbetalning</a>
             <a class="nav-link" href="#kap9">9 Medlemsbevis</a>
             <a class="nav-link" href="#kap10">10 Ankomstregistrering</a>
             <a class="nav-link" href="#kap11">11 Förändring av personliga uppgifter</a>
@@ -883,21 +883,21 @@
             <a class="nav-link" href="#kap13">13 Marknadsföring</a>
             <a class="nav-link" href="#kap14">14 Kläder för kurs och tävling</a>
             <a class="nav-link" href="#kap15">15 Grafisk profil</a>
-            <a class="nav-link section" href="#kap15-1">15.1 Logotyp</a>
-            <a class="nav-link section" href="#kap15-2">15.2 Färg</a>
-            <a class="nav-link section" href="#kap15-3">15.3 Format och typsnitt</a>
-            <a class="nav-link section" href="#kap15-4">15.4 Föreningsrelaterade kläder och associerar</a>
+            <a class="nav-link avsnitt" href="#kap15-1">15.1 Logotyp</a>
+            <a class="nav-link avsnitt" href="#kap15-2">15.2 Färg</a>
+            <a class="nav-link avsnitt" href="#kap15-3">15.3 Format och typsnitt</a>
+            <a class="nav-link avsnitt" href="#kap15-4">15.4 Föreningsrelaterade kläder och associerar</a>
             <a class="nav-link" href="#kap16">16 Ekonomi</a>
-            <a class="nav-link section" href="#kap16-1">16.1 Inköp</a>
-            <a class="nav-link section" href="#kap16-2">16.2 Arvode</a>
-            <a class="nav-link section" href="#kap16-3">16.3 Bidrag/stipendium</a>
+            <a class="nav-link avsnitt" href="#kap16-1">16.1 Inköp</a>
+            <a class="nav-link avsnitt" href="#kap16-2">16.2 Arvode</a>
+            <a class="nav-link avsnitt" href="#kap16-3">16.3 Bidrag/stipendium</a>
             <a class="nav-link" href="#kap17">17 Kläder och accessoarer</a>
             <a class="nav-link" href="#kap18">18 Medlemsrabatter</a>
-            <a class="nav-link section" href="#kap18-1">18.1 Kurser</a>
-            <a class="nav-link section" href="#kap18-2">18.2 Studentrabatt</a>
-            <a class="nav-link section" href="#kap18-3">18.3 Pensionärsrabatt</a>
-            <a class="nav-link section" href="#kap18-4">18.4 Fritidskortet</a>
-            <a class="nav-link section" href="#kap18-5">18.5 Medlemsrabatter i företag</a>
+            <a class="nav-link avsnitt" href="#kap18-1">18.1 Kurser</a>
+            <a class="nav-link avsnitt" href="#kap18-2">18.2 Studentrabatt</a>
+            <a class="nav-link avsnitt" href="#kap18-3">18.3 Pensionärsrabatt</a>
+            <a class="nav-link avsnitt" href="#kap18-4">18.4 Fritidskortet</a>
+            <a class="nav-link avsnitt" href="#kap18-5">18.5 Medlemsrabatter i företag</a>
           </nav>
         </nav>
       </div><!-- end col-lg-3 order-lg-2 -->

--- a/src/foreningen/styrande-dokument/dkrr-002-arshjul-och-arbetsprocesser/index.php
+++ b/src/foreningen/styrande-dokument/dkrr-002-arshjul-och-arbetsprocesser/index.php
@@ -779,22 +779,22 @@
         <h3 class="scrollspy-heading">Innehållsförteckning</h3>
         <nav class="nav nav-pills flex-column">
           <a class="nav-link" href="#kap1">1 Inledning</a>
-          <a class="nav-link section" href="#kap1-1">1.1 Bakgrund</a>
-          <a class="nav-link section" href="#kap1-2">1.2 Syfte</a>
-          <a class="nav-link section" href="#kap1-3">1.3 Versionshistorik</a>
+          <a class="nav-link avsnitt" href="#kap1-1">1.1 Bakgrund</a>
+          <a class="nav-link avsnitt" href="#kap1-2">1.2 Syfte</a>
+          <a class="nav-link avsnitt" href="#kap1-3">1.3 Versionshistorik</a>
           <a class="nav-link" href="#kap2">2 DKRR Årshjul - Aktiviteter</a>
-          <a class="nav-link section" href="#januari">2.1 Januari</a>
-          <a class="nav-link section" href="#februari">2.2 Februari</a>
-          <a class="nav-link section" href="#mars">2.3 Mars</a>
-          <a class="nav-link section" href="#april">2.4 April</a>
-          <a class="nav-link section" href="#maj">2.5 Maj</a>
-          <a class="nav-link section" href="#juni">2.6 Juni</a>
-          <a class="nav-link section" href="#juli">2.7 Juli</a>
-          <a class="nav-link section" href="#augusti">2.8 Augusti</a>
-          <a class="nav-link section" href="#september">2.9 September</a>
-          <a class="nav-link section" href="#oktober">2.10 Oktober</a>
-          <a class="nav-link section" href="#november">2.11 November</a>
-          <a class="nav-link section" href="#december">2.12 December</a>
+          <a class="nav-link avsnitt" href="#januari">2.1 Januari</a>
+          <a class="nav-link avsnitt" href="#februari">2.2 Februari</a>
+          <a class="nav-link avsnitt" href="#mars">2.3 Mars</a>
+          <a class="nav-link avsnitt" href="#april">2.4 April</a>
+          <a class="nav-link avsnitt" href="#maj">2.5 Maj</a>
+          <a class="nav-link avsnitt" href="#juni">2.6 Juni</a>
+          <a class="nav-link avsnitt" href="#juli">2.7 Juli</a>
+          <a class="nav-link avsnitt" href="#augusti">2.8 Augusti</a>
+          <a class="nav-link avsnitt" href="#september">2.9 September</a>
+          <a class="nav-link avsnitt" href="#oktober">2.10 Oktober</a>
+          <a class="nav-link avsnitt" href="#november">2.11 November</a>
+          <a class="nav-link avsnitt" href="#december">2.12 December</a>
         </nav>
       </nav>
     </div><!-- end col-lg-3 order-lg-2 -->

--- a/src/foreningen/styrande-dokument/dkrr-003-stadgar/index.php
+++ b/src/foreningen/styrande-dokument/dkrr-003-stadgar/index.php
@@ -341,51 +341,51 @@
           <h3 class="scrollspy-heading">Innehållsförteckning</h3>
           <nav class="nav nav-pills flex-column">
             <a class="nav-link" href="#kap0--rubrik">Idrottsrörelsens verksamhetsidé</a>
-            <a class="nav-link section" href="#kap0-p1">Definition</a>
-            <a class="nav-link section" href="#kap0-p2">Mål och inriktning</a>
+            <a class="nav-link paragraf" href="#kap0-p1">Definition</a>
+            <a class="nav-link paragraf" href="#kap0-p2">Mål och inriktning</a>
             <a class="nav-link" href="#kap1--rubrik">1 kap Allmänna bestämmelser</a>
-            <a class="nav-link section" href="#kap1-p1">1 § Ändamål</a>
-            <a class="nav-link section" href="#kap1-p2">2 § Föreningens namn m.m</a>
-            <a class="nav-link section" href="#kap1-p3">3 § Sammansättning, tillhörighet m.m</a>
-            <a class="nav-link section" href="#kap1-p4">4 § Beslutande organ</a>
-            <a class="nav-link section" href="#kap1-p5">5 § Verksamhets- och räkenskapsår</a>
-            <a class="nav-link section" href="#kap1-p6">6 § Firmateckning</a>
-            <a class="nav-link section" href="#kap1-p7">7 § Stadgeändring</a>
-            <a class="nav-link section" href="#kap1-p8">8 § Tvist/skiljeklausul</a>
-            <a class="nav-link section" href="#kap1-p9">9 § Upplösning av föreningen</a>
+            <a class="nav-link paragraf" href="#kap1-p1">1 § Ändamål</a>
+            <a class="nav-link paragraf" href="#kap1-p2">2 § Föreningens namn m.m</a>
+            <a class="nav-link paragraf" href="#kap1-p3">3 § Sammansättning, tillhörighet m.m</a>
+            <a class="nav-link paragraf" href="#kap1-p4">4 § Beslutande organ</a>
+            <a class="nav-link paragraf" href="#kap1-p5">5 § Verksamhets- och räkenskapsår</a>
+            <a class="nav-link paragraf" href="#kap1-p6">6 § Firmateckning</a>
+            <a class="nav-link paragraf" href="#kap1-p7">7 § Stadgeändring</a>
+            <a class="nav-link paragraf" href="#kap1-p8">8 § Tvist/skiljeklausul</a>
+            <a class="nav-link paragraf" href="#kap1-p9">9 § Upplösning av föreningen</a>
             <a class="nav-link" href="#kap2--rubrik">2 kap Föreningens medlemmar</a>
-            <a class="nav-link section" href="#kap2-p1">1 § Medlemskap</a>
-            <a class="nav-link section" href="#kap2-p2">2 § Medlems skyldigheter och rättigheter</a>
-            <a class="nav-link section" href="#kap2-p3">3 § Medlems deltagande i tävlingsverksamhet</a>
-            <a class="nav-link section" href="#kap2-p4">4 § Utträde</a>
-            <a class="nav-link section" href="#kap2-p5">5 § Uteslutning m.m.</a>
-            <a class="nav-link section" href="#kap2-p6">6 § Överklagande</a>
-            <a class="nav-link section" href="#kap2-p7">7 § Medlemskapets upphörande</a>
+            <a class="nav-link paragraf" href="#kap2-p1">1 § Medlemskap</a>
+            <a class="nav-link paragraf" href="#kap2-p2">2 § Medlems skyldigheter och rättigheter</a>
+            <a class="nav-link paragraf" href="#kap2-p3">3 § Medlems deltagande i tävlingsverksamhet</a>
+            <a class="nav-link paragraf" href="#kap2-p4">4 § Utträde</a>
+            <a class="nav-link paragraf" href="#kap2-p5">5 § Uteslutning m.m.</a>
+            <a class="nav-link paragraf" href="#kap2-p6">6 § Överklagande</a>
+            <a class="nav-link paragraf" href="#kap2-p7">7 § Medlemskapets upphörande</a>
             <a class="nav-link" href="#kap3--rubrik">3 kap Årsmöte</a>
-            <a class="nav-link section" href="#kap3-p1">1 § Tidpunkt och kallelse</a>
-            <a class="nav-link section" href="#kap3-p2">2 § Förslag till ärenden att behandlas av årsmötet</a>
-            <a class="nav-link section" href="#kap3-p3">3 § Sammansättning och beslutförhet</a>
-            <a class="nav-link section" href="#kap3-p4">4 § Rösträtt samt yttrande- och förslagsrätt på årsmötet</a>
-            <a class="nav-link section" href="#kap3-p5">5 § Ärenden vid årsmötet</a>
-            <a class="nav-link section" href="#kap3-p6">6 § Valbarhet</a>
-            <a class="nav-link section" href="#kap3-p7">7 § Extra årsmöte</a>
-            <a class="nav-link section" href="#kap3-p8">8 § Beslut och omröstning</a>
-            <a class="nav-link section" href="#kap3-p9">9 § Ikraftträdande</a>
+            <a class="nav-link paragraf" href="#kap3-p1">1 § Tidpunkt och kallelse</a>
+            <a class="nav-link paragraf" href="#kap3-p2">2 § Förslag till ärenden att behandlas av årsmötet</a>
+            <a class="nav-link paragraf" href="#kap3-p3">3 § Sammansättning och beslutförhet</a>
+            <a class="nav-link paragraf" href="#kap3-p4">4 § Rösträtt samt yttrande- och förslagsrätt på årsmötet</a>
+            <a class="nav-link paragraf" href="#kap3-p5">5 § Ärenden vid årsmötet</a>
+            <a class="nav-link paragraf" href="#kap3-p6">6 § Valbarhet</a>
+            <a class="nav-link paragraf" href="#kap3-p7">7 § Extra årsmöte</a>
+            <a class="nav-link paragraf" href="#kap3-p8">8 § Beslut och omröstning</a>
+            <a class="nav-link paragraf" href="#kap3-p9">9 § Ikraftträdande</a>
             <a class="nav-link" href="#kap4--rubrik">4 kap Valberedning</a>
-            <a class="nav-link section" href="#kap4-p1">1 § Sammansättning</a>
-            <a class="nav-link section" href="#kap4-p2">2 § Åligganden</a>
+            <a class="nav-link paragraf" href="#kap4-p1">1 § Sammansättning</a>
+            <a class="nav-link paragraf" href="#kap4-p2">2 § Åligganden</a>
             <a class="nav-link" href="#kap5--rubrik">5 kap Revision</a>
-            <a class="nav-link section" href="#kap5-p1">1 § Revisorer och revision</a>
+            <a class="nav-link paragraf" href="#kap5-p1">1 § Revisorer och revision</a>
             <a class="nav-link" href="#kap6--rubrik">6 kap Styrelsen</a>
-            <a class="nav-link section" href="#kap6-p1">1 § Sammansättning</a>
-            <a class="nav-link section" href="#kap6-p2">2 § Styrelsens åligganden</a>
-            <a class="nav-link section" href="#kap6-p3">3 § Kallelse, beslutförhet och omröstning</a>
-            <a class="nav-link section" href="#kap6-p4">4 § Överlåtelse av beslutanderätten</a>
+            <a class="nav-link paragraf" href="#kap6-p1">1 § Sammansättning</a>
+            <a class="nav-link paragraf" href="#kap6-p2">2 § Styrelsens åligganden</a>
+            <a class="nav-link paragraf" href="#kap6-p3">3 § Kallelse, beslutförhet och omröstning</a>
+            <a class="nav-link paragraf" href="#kap6-p4">4 § Överlåtelse av beslutanderätten</a>
             <a class="nav-link" href="#kap7--rubrik">7 kap Övriga föreningsorgan</a>
-            <a class="nav-link section" href="#kap7-p1">1 § Kommittéer, arbetsgrupper och andra underliggande föreningsorgan</a>
-            <a class="nav-link section" href="#kap7-p2">2 § Instruktioner</a>
-            <a class="nav-link section" href="#kap7-p3">3 § Budget och verksamhetsplan</a>
-            <a class="nav-link section" href="#kap7-p4">4 § Återrapportering</a>
+            <a class="nav-link paragraf" href="#kap7-p1">1 § Kommittéer, arbetsgrupper och andra underliggande föreningsorgan</a>
+            <a class="nav-link paragraf" href="#kap7-p2">2 § Instruktioner</a>
+            <a class="nav-link paragraf" href="#kap7-p3">3 § Budget och verksamhetsplan</a>
+            <a class="nav-link paragraf" href="#kap7-p4">4 § Återrapportering</a>
           </nav>
         </nav>
       </div><!-- end col-lg-3 order-lg-2 -->

--- a/src/foreningen/styrande-dokument/dkrr-004-organisation-och-rollbeskrivning/index.php
+++ b/src/foreningen/styrande-dokument/dkrr-004-organisation-och-rollbeskrivning/index.php
@@ -44,67 +44,67 @@
               <h1>Innehållsförteckning</h1>
             </div>
             <div class="kapitel"><a href="#kap1">1 Inledning</a></div>
-            <div class="section"><a href="#kap1-1">1.1 Bakgrund</a></div>
-            <div class="section"><a href="#kap1-2">1.2 Syfte</a></div>
-            <div class="section"><a href="#kap1-3">1.3 Versionshistorik</a></div>
-            <div class="section"><a href="#kap1-4">1.4 Avgränsningar</a></div>
+            <div class="avsnitt"><a href="#kap1-1">1.1 Bakgrund</a></div>
+            <div class="avsnitt"><a href="#kap1-2">1.2 Syfte</a></div>
+            <div class="avsnitt"><a href="#kap1-3">1.3 Versionshistorik</a></div>
+            <div class="avsnitt"><a href="#kap1-4">1.4 Avgränsningar</a></div>
             <div class="kapitel"><a href="#kap2">2 Organisation</a></div>
             <div class="kapitel"><a href="#kap3">3 Gemensamma riktlinjer och förväntningar</a></div>
             <div class="kapitel"><a href="#kap4">4 Roll- och uppdragsbeskrivning</a></div>
-            <div class="section"><a href="#kap4-1">4.1 Styrelse</a></div>
-            <div class="subsection"><a href="#kap4-1-1">4.1.1 Firmatecknare</a></div>
-            <div class="subsection"><a href="#kap4-1-2">4.1.2 Ordförande</a></div>
-            <div class="subsection"><a href="#kap4-1-3">4.1.3 Vice ordförande</a></div>
-            <div class="subsection"><a href="#kap4-1-4">4.1.4 Ledamot</a></div>
-            <div class="subsection"><a href="#kap4-1-5">4.1.5 Suppleant</a></div>
-            <div class="subsection"><a href="#kap4-1-6">4.1.6 Sekreterare</a></div>
-            <div class="subsection"><a href="#kap4-1-7">4.1.7 Kassör</a></div>
-            <div class="section"><a href="#kap4-2">4.2 Valberedning</a></div>
-            <div class="subsection"><a href="#kap4-2-1">4.2.1 Ordförande</a></div>
-            <div class="subsection"><a href="#kap4-2-2">4.2.2 Ledamot</a></div>
-            <div class="section"><a href="#kap4-3">4.3 Revisor</a></div>
-            <div class="section"><a href="#kap4-4">4.4 Danskommitté</a></div>
-            <div class="subsection"><a href="#kap4-4-1">4.4.1 Danskommittéansvarig</a></div>
-            <div class="subsection"><a href="#kap4-4-2">4.4.2 Tränar- och utbildningsansvarig</a></div>
-            <div class="subsection"><a href="#kap4-4-3">4.4.3 Kursadministratör</a></div>
-            <div class="subsection"><a href="#kap4-4-4">4.4.4 Marknadsföringsansvarig (sociala media) </a></div>
-            <div class="subsection"><a href="#kap4-4-5">4.4.5 Tävlingsansvarig</a></div>
-            <div class="subsection"><a href="#kap4-4-6">4.4.6 Tävlingsverksamhet</a></div>
-            <div class="subsection"><a href="#kap4-4-7">4.4.7 Socialdansansvarig</a></div>
-            <div class="subsection"><a href="#kap4-4-8">4.4.8 Musikansvarig</a></div>
-            <div class="subsection"><a href="#kap4-4-9">4.4.9 Tränare</a></div>
-            <div class="subsection"><a href="#kap4-4-10">4.4.10 Assistent</a></div>
-            <div class="subsection"><a href="#kap4-4-11">4.4.11 Hjälpdansare</a></div>
-            <div class="section"><a href="#kap4-5">4.5 Ungdomskommitté</a></div>
-            <div class="subsection"><a href="#kap4-5-1">4.5.1 Ungdomskommittéansvarig</a></div>
-            <div class="subsection"><a href="#kap4-5-2">4.5.2 Genomförandegrupp</a></div>
-            <div class="section"><a href="#kap4-6">4.6 Teknikkommitté</a></div>
-            <div class="subsection"><a href="#kap4-6-1">4.6.1 Teknikkommittéansvarig</a></div>
-            <div class="subsection"><a href="#kap4-6-2">4.6.2 Genomförandegrupp</a></div>
-            <div class="section"><a href="#kap4-7">4.7 Festkommitté</a></div>
-            <div class="subsection"><a href="#kap4-7-1">4.7.1 Festkommittéansvarig</a></div>
-            <div class="subsection"><a href="#kap4-7-2">4.7.2 Genomförandegrupp</a></div>
-            <div class="section"><a href="#kap4-8">4.8 Föreningsgemensamma roller</a></div>
-            <div class="subsection"><a href="#kap4-8-1">4.8.1 Rollutbildningsansvarig</a></div>
-            <div class="subsection"><a href="#kap4-8-2">4.8.2 Bidragsansvarig</a></div>
-            <div class="subsection"><a href="#kap4-8-3">4.8.3 Marknadsföringsansvarig</a></div>
-            <div class="subsection"><a href="#kap4-8-4">4.8.4 Lokalansvarig</a></div>
-            <div class="subsection"><a href="#kap4-8-5">4.8.5 Dataskyddsombud</a></div>
-            <div class="subsection"><a href="#kap4-8-6">4.8.6 Café och receptionsansvarig</a></div>
+            <div class="avsnitt"><a href="#kap4-1">4.1 Styrelse</a></div>
+            <div class="underavsnitt"><a href="#kap4-1-1">4.1.1 Firmatecknare</a></div>
+            <div class="underavsnitt"><a href="#kap4-1-2">4.1.2 Ordförande</a></div>
+            <div class="underavsnitt"><a href="#kap4-1-3">4.1.3 Vice ordförande</a></div>
+            <div class="underavsnitt"><a href="#kap4-1-4">4.1.4 Ledamot</a></div>
+            <div class="underavsnitt"><a href="#kap4-1-5">4.1.5 Suppleant</a></div>
+            <div class="underavsnitt"><a href="#kap4-1-6">4.1.6 Sekreterare</a></div>
+            <div class="underavsnitt"><a href="#kap4-1-7">4.1.7 Kassör</a></div>
+            <div class="avsnitt"><a href="#kap4-2">4.2 Valberedning</a></div>
+            <div class="underavsnitt"><a href="#kap4-2-1">4.2.1 Ordförande</a></div>
+            <div class="underavsnitt"><a href="#kap4-2-2">4.2.2 Ledamot</a></div>
+            <div class="avsnitt"><a href="#kap4-3">4.3 Revisor</a></div>
+            <div class="avsnitt"><a href="#kap4-4">4.4 Danskommitté</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-1">4.4.1 Danskommittéansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-2">4.4.2 Tränar- och utbildningsansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-3">4.4.3 Kursadministratör</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-4">4.4.4 Marknadsföringsansvarig (sociala media) </a></div>
+            <div class="underavsnitt"><a href="#kap4-4-5">4.4.5 Tävlingsansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-6">4.4.6 Tävlingsverksamhet</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-7">4.4.7 Socialdansansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-8">4.4.8 Musikansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-9">4.4.9 Tränare</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-10">4.4.10 Assistent</a></div>
+            <div class="underavsnitt"><a href="#kap4-4-11">4.4.11 Hjälpdansare</a></div>
+            <div class="avsnitt"><a href="#kap4-5">4.5 Ungdomskommitté</a></div>
+            <div class="underavsnitt"><a href="#kap4-5-1">4.5.1 Ungdomskommittéansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-5-2">4.5.2 Genomförandegrupp</a></div>
+            <div class="avsnitt"><a href="#kap4-6">4.6 Teknikkommitté</a></div>
+            <div class="underavsnitt"><a href="#kap4-6-1">4.6.1 Teknikkommittéansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-6-2">4.6.2 Genomförandegrupp</a></div>
+            <div class="avsnitt"><a href="#kap4-7">4.7 Festkommitté</a></div>
+            <div class="underavsnitt"><a href="#kap4-7-1">4.7.1 Festkommittéansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-7-2">4.7.2 Genomförandegrupp</a></div>
+            <div class="avsnitt"><a href="#kap4-8">4.8 Föreningsgemensamma roller</a></div>
+            <div class="underavsnitt"><a href="#kap4-8-1">4.8.1 Rollutbildningsansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-8-2">4.8.2 Bidragsansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-8-3">4.8.3 Marknadsföringsansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-8-4">4.8.4 Lokalansvarig</a></div>
+            <div class="underavsnitt"><a href="#kap4-8-5">4.8.5 Dataskyddsombud</a></div>
+            <div class="underavsnitt"><a href="#kap4-8-6">4.8.6 Café och receptionsansvarig</a></div>
             <p>&nbsp;</p>
           </div><!-- end document-toc -->
 
     <h2 class="kapitel"><a id="kap1" href="#kap1" class="anchor-link">🔗</a>1 Inledning</h2>
-    <h3 class="section"><a id="kap1-1" href="#kap1-1" class="anchor-link">🔗</a>1.1 Bakgrund</h3>
+    <h3 class="avsnitt"><a id="kap1-1" href="#kap1-1" class="anchor-link">🔗</a>1.1 Bakgrund</h3>
     <p>En grundläggande förutsättning till en fungerande och hållbar föreningsverksamhet är att det finns tydliga riktlinjer hur verksamheten ska bedrivas. Dessa riktlinjer utgörs av styrande dokument så som stadgar, arbetsbeskrivningar och policydokument. Genom dessa dokument skapas ett grundfundament som stärker föreningens förmåga att upprätthålla kvalitet samt säkerställa kontinuitet vid förändringar i organisationens bemanning.</p>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap1-2" href="#kap1-2" class="anchor-link">🔗</a>1.2 Syfte</h3>
+    <h3 class="avsnitt"><a id="kap1-2" href="#kap1-2" class="anchor-link">🔗</a>1.2 Syfte</h3>
     <p>Syftet med detta dokument är att beskriva föreningens organisation och roller. Dokumentet ger stöd i det dagliga arbetet och underlättar introduktion av nya rollinnehavare i föreningen.</p>
     <p>Dokumentet ses över minst en gång per år och uppdateras vid behov. Styrelsen tar tacksamt emot synpunkter på innehållet. Synpunkter och frågeställningar skickas till: <a href="mailto:styrelsen@rockrullarna.se">styrelsen@rockrullarna.se</a></p>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap1-3" href="#kap1-3" class="anchor-link">🔗</a>1.3 Versionshistorik</h3>
+    <h3 class="avsnitt"><a id="kap1-3" href="#kap1-3" class="anchor-link">🔗</a>1.3 Versionshistorik</h3>
     <table class="version-table">
       <tr>
         <th>Utgåva</th>
@@ -145,7 +145,7 @@
     </table>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap1-4" href="#kap1-4" class="anchor-link">🔗</a>1.4 Avgränsningar</h3>
+    <h3 class="avsnitt"><a id="kap1-4" href="#kap1-4" class="anchor-link">🔗</a>1.4 Avgränsningar</h3>
     <p>Detta dokument är avgränsat till att beskriva och föreningens organisation och roller. Information om föreningens grundläggande aktiviteter samt arbetsprocesser framgår i dokument <a href="../dkrr-002-arshjul-och-arbetsprocesser" title="DKRR-002 Årshjul och arbetsprocesser">"DKRR-002, Årshjul och arbetsprocesser"</a>.</p>
     <p>&nbsp;</p>
 
@@ -335,7 +335,7 @@
     <p>&nbsp;</p>
 
     <h2 class="kapitel"><a id="kap4" href="#kap4" class="anchor-link">🔗</a>4 Roll- och uppdragsbeskrivning</h2>
-    <h3 class="section"><a id="kap4-1" href="#kap4-1" class="anchor-link">🔗</a>4.1 Styrelse</h3>
+    <h3 class="avsnitt"><a id="kap4-1" href="#kap4-1" class="anchor-link">🔗</a>4.1 Styrelse</h3>
     <p>Styrelsen har det övergripande ansvaret att leda och utveckla föreningens verksamhet i enlighet med föreningens stadgar och verksamhetsmål samt styrande direktiv från Riksidrottsförbundet och Danssportsförbundet. Styrelsens är förtroendevalda av medlemmarna och ska verka för att skapa en trygg, inkluderande och inspirerande miljö där medlemmar i alla åldrar och nivåer kan utöva dans och delta i föreningslivet.</p>
 
     <h4>Övergripande ansvar</h4>
@@ -487,7 +487,7 @@
       <li>Grundläggande utbildning i styrelsearbete.</li>
       <li>Utbildning i föreningens teknik och IT-miljö.</li>
     </ul>
-    <h3 class="section"><a id="kap4-2" href="#kap4-2" class="anchor-link">🔗</a>4.2 Valberedning</h3>
+    <h3 class="avsnitt"><a id="kap4-2" href="#kap4-2" class="anchor-link">🔗</a>4.2 Valberedning</h3>
     <p>Valberednings arbetsuppgift är att ge förslag till revisorer och ledamöter till styrelsen. Valberedningen är fristående från styrelsen, ska kontinuerligt följa verksamheten och söka efter personer som tillsammans utger en bra representation av föreningens medlemmar.</p>
 
     <h4><a id="kap4-2-1" href="#kap4-2-1" class="anchor-link">🔗</a>4.2.1 Ordförande</h4>
@@ -528,7 +528,7 @@
     </ul>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap4-3" href="#kap4-3" class="anchor-link">🔗</a>4.3 Revisor</h3>
+    <h3 class="avsnitt"><a id="kap4-3" href="#kap4-3" class="anchor-link">🔗</a>4.3 Revisor</h3>
     <h4>Uppdragsbeskrivning</h4>
     <p>Revisorernas ansvar är att granska föreningens årsredovisning, bokföring (räkenskaps-revision), föreningsledningens förvaltning (förvaltningsrevision) och lämna ett utlåtande om granskningsutfallet på föreningens årsmöte.</p>
     <p>Revisorerna har rapporteringsskyldighet till olika intressenter vid speciella omständigheter. Om revisorerna finner misstankar om brott inom verksamheten t.ex. förskingring, bokföringsbrott, mutbrott eller skattebrott, ska revisorerna anmäla misstanken och grunden för detta till åklagare.</p>
@@ -576,7 +576,7 @@
     </ul>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap4-4" href="#kap4-4" class="anchor-link">🔗</a>4.4 Danskommitté</h3>
+    <h3 class="avsnitt"><a id="kap4-4" href="#kap4-4" class="anchor-link">🔗</a>4.4 Danskommitté</h3>
     <p>DKRR består av följande danskommittéer: </p>
     <ul>
       <li>1 st Bugg-kommitté</li>
@@ -861,7 +861,7 @@
     </ul>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap4-5" href="#kap4-5" class="anchor-link">🔗</a>4.5 Ungdomskommitté</h3>
+    <h3 class="avsnitt"><a id="kap4-5" href="#kap4-5" class="anchor-link">🔗</a>4.5 Ungdomskommitté</h3>
     <p>Ungdomskommittén arbetar för att väcka dansintresse hos ungdomar och öka engagemanget bland ungdomar i föreningen.</p>
 
     <h4>Ekonomiskt ansvar och befogenheter</h4>
@@ -931,7 +931,7 @@
     </ul>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap4-6" href="#kap4-6" class="anchor-link">🔗</a>4.6 Teknikkommitté</h3>
+    <h3 class="avsnitt"><a id="kap4-6" href="#kap4-6" class="anchor-link">🔗</a>4.6 Teknikkommitté</h3>
     <p>Teknikkommittén ansvarar för all teknisk utrustning inom dansföreningen och säkerställer att teknik som ljud/bild och IT-miljö (inkl. hemsida) är i fungerande skick och anpassade efter föreningens behov.</p>
     <p>&nbsp;</p>
 
@@ -979,7 +979,7 @@
     </ul>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap4-7" href="#kap4-7" class="anchor-link">🔗</a>4.7 Festkommitté</h3>
+    <h3 class="avsnitt"><a id="kap4-7" href="#kap4-7" class="anchor-link">🔗</a>4.7 Festkommitté</h3>
     <p>Festkommittén ansvarar för att planera och genomföra sociala evenemang och fester på uppdrag av styrelsen och danskommittéerna. Festkommittén utgör en viktig del i att skapa en välkomnande och trivsam miljö för föreningens medlemmar.</p>
     <p>&nbsp;</p>
 
@@ -1019,7 +1019,7 @@
     </ul>
     <p>&nbsp;</p>
 
-    <h3 class="section"><a id="kap4-8" href="#kap4-8" class="anchor-link">🔗</a>4.8 Föreningsgemensamma roller</h3>
+    <h3 class="avsnitt"><a id="kap4-8" href="#kap4-8" class="anchor-link">🔗</a>4.8 Föreningsgemensamma roller</h3>
     <p>Med föreningsgemensamma roller menas roller som varken ingår i styrelsen eller kommittéer men som är centrala och gemensamma för föreningen.</p>
     <p>&nbsp;</p>
 
@@ -1160,53 +1160,53 @@
           <h3 class="scrollspy-heading">Innehållsförteckning</h3>
           <nav class="nav nav-pills flex-column">
             <a class="nav-link" href="#kap1">1 Inledning</a>
-            <a class="nav-link section" href="#kap1-1">1.1 Bakgrund</a>
-            <a class="nav-link section" href="#kap1-2">1.2 Syfte</a>
-            <a class="nav-link section" href="#kap1-3">1.3 Versionshistorik</a>
-            <a class="nav-link section" href="#kap1-4">1.4 Avgränsningar</a>
+            <a class="nav-link avsnitt" href="#kap1-1">1.1 Bakgrund</a>
+            <a class="nav-link avsnitt" href="#kap1-2">1.2 Syfte</a>
+            <a class="nav-link avsnitt" href="#kap1-3">1.3 Versionshistorik</a>
+            <a class="nav-link avsnitt" href="#kap1-4">1.4 Avgränsningar</a>
             <a class="nav-link" href="#kap2">2 Organisation</a>
             <a class="nav-link" href="#kap3">3 Gemensamma riktlinjer och förväntningar</a>
             <a class="nav-link" href="#kap4">4 Roll- och uppdragsbeskrivning</a>
-            <a class="nav-link section" href="#kap4-1">4.1 Styrelse</a>
-            <a class="nav-link section" href="#kap4-1-1">4.1.1 Firmatecknare</a>
-            <a class="nav-link section" href="#kap4-1-2">4.1.2 Ordförande</a>
-            <a class="nav-link section" href="#kap4-1-3">4.1.3 Vice ordförande</a>
-            <a class="nav-link section" href="#kap4-1-4">4.1.4 Ledamot</a>
-            <a class="nav-link section" href="#kap4-1-5">4.1.5 Suppleant</a>
-            <a class="nav-link section" href="#kap4-1-6">4.1.6 Sekreterare</a>
-            <a class="nav-link section" href="#kap4-1-7">4.1.7 Kassör</a>
-            <a class="nav-link section" href="#kap4-2">4.2 Valberedning</a>
-            <a class="nav-link section" href="#kap4-2-1">4.2.1 Ordförande</a>
-            <a class="nav-link section" href="#kap4-2-2">4.2.2 Ledamot</a>
-            <a class="nav-link section" href="#kap4-3">4.3 Revisor</a>
-            <a class="nav-link section" href="#kap4-4">4.4 Danskommitté</a>
-            <a class="nav-link section" href="#kap4-4-1">4.4.1 Danskommittéansvarig</a>
-            <a class="nav-link section" href="#kap4-4-2">4.4.2 Tränar- och utbildningsansvarig</a>
-            <a class="nav-link section" href="#kap4-4-3">4.4.3 Kursadministratör</a>
-            <a class="nav-link section" href="#kap4-4-4">4.4.4 Marknadsföringsansvarig (sociala media) </a>
-            <a class="nav-link section" href="#kap4-4-5">4.4.5 Tävlingsansvarig</a>
-            <a class="nav-link section" href="#kap4-4-6">4.4.6 Tävlingsverksamhet</a>
-            <a class="nav-link section" href="#kap4-4-7">4.4.7 Socialdansansvarig</a>
-            <a class="nav-link section" href="#kap4-4-8">4.4.8 Musikansvarig</a>
-            <a class="nav-link section" href="#kap4-4-9">4.4.9 Tränare</a>
-            <a class="nav-link section" href="#kap4-4-10">4.4.10 Assistent</a>
-            <a class="nav-link section" href="#kap4-4-11">4.4.11 Hjälpdansare</a>
-            <a class="nav-link section" href="#kap4-5">4.5 Ungdomskommitté</a>
-            <a class="nav-link section" href="#kap4-5-1">4.5.1 Ungdomskommittéansvarig</a>
-            <a class="nav-link section" href="#kap4-5-2">4.5.2 Genomförandegrupp</a>
-            <a class="nav-link section" href="#kap4-6">4.6 Teknikkommitté</a>
-            <a class="nav-link section" href="#kap4-6-1">4.6.1 Teknikkommittéansvarig</a>
-            <a class="nav-link section" href="#kap4-6-2">4.6.2 Genomförandegrupp</a>
-            <a class="nav-link section" href="#kap4-7">4.7 Festkommitté</a>
-            <a class="nav-link section" href="#kap4-7-1">4.7.1 Festkommittéansvarig</a>
-            <a class="nav-link section" href="#kap4-7-2">4.7.2 Genomförandegrupp</a>
-            <a class="nav-link section" href="#kap4-8">4.8 Föreningsgemensamma roller</a>
-            <a class="nav-link section" href="#kap4-8-1">4.8.1 Rollutbildningsansvarig</a>
-            <a class="nav-link section" href="#kap4-8-2">4.8.2 Bidragsansvarig</a>
-            <a class="nav-link section" href="#kap4-8-3">4.8.3 Marknadsföringsansvarig</a>
-            <a class="nav-link section" href="#kap4-8-4">4.8.4 Lokalansvarig</a>
-            <a class="nav-link section" href="#kap4-8-5">4.8.5 Dataskyddsombud</a>
-            <a class="nav-link section" href="#kap4-8-6">4.8.6 Café och receptionsansvarig</a>
+            <a class="nav-link avsnitt" href="#kap4-1">4.1 Styrelse</a>
+            <a class="nav-link underavsnitt" href="#kap4-1-1">4.1.1 Firmatecknare</a>
+            <a class="nav-link underavsnitt" href="#kap4-1-2">4.1.2 Ordförande</a>
+            <a class="nav-link underavsnitt" href="#kap4-1-3">4.1.3 Vice ordförande</a>
+            <a class="nav-link underavsnitt" href="#kap4-1-4">4.1.4 Ledamot</a>
+            <a class="nav-link underavsnitt" href="#kap4-1-5">4.1.5 Suppleant</a>
+            <a class="nav-link underavsnitt" href="#kap4-1-6">4.1.6 Sekreterare</a>
+            <a class="nav-link underavsnitt" href="#kap4-1-7">4.1.7 Kassör</a>
+            <a class="nav-link avsnitt" href="#kap4-2">4.2 Valberedning</a>
+            <a class="nav-link underavsnitt" href="#kap4-2-1">4.2.1 Ordförande</a>
+            <a class="nav-link underavsnitt" href="#kap4-2-2">4.2.2 Ledamot</a>
+            <a class="nav-link avsnitt" href="#kap4-3">4.3 Revisor</a>
+            <a class="nav-link avsnitt" href="#kap4-4">4.4 Danskommitté</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-1">4.4.1 Danskommittéansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-2">4.4.2 Tränar- och utbildningsansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-3">4.4.3 Kursadministratör</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-4">4.4.4 Marknadsföringsansvarig (sociala media) </a>
+            <a class="nav-link underavsnitt" href="#kap4-4-5">4.4.5 Tävlingsansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-6">4.4.6 Tävlingsverksamhet</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-7">4.4.7 Socialdansansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-8">4.4.8 Musikansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-9">4.4.9 Tränare</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-10">4.4.10 Assistent</a>
+            <a class="nav-link underavsnitt" href="#kap4-4-11">4.4.11 Hjälpdansare</a>
+            <a class="nav-link avsnitt" href="#kap4-5">4.5 Ungdomskommitté</a>
+            <a class="nav-link underavsnitt" href="#kap4-5-1">4.5.1 Ungdomskommittéansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-5-2">4.5.2 Genomförandegrupp</a>
+            <a class="nav-link avsnitt" href="#kap4-6">4.6 Teknikkommitté</a>
+            <a class="nav-link underavsnitt" href="#kap4-6-1">4.6.1 Teknikkommittéansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-6-2">4.6.2 Genomförandegrupp</a>
+            <a class="nav-link avsnitt" href="#kap4-7">4.7 Festkommitté</a>
+            <a class="nav-link underavsnitt" href="#kap4-7-1">4.7.1 Festkommittéansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-7-2">4.7.2 Genomförandegrupp</a>
+            <a class="nav-link avsnitt" href="#kap4-8">4.8 Föreningsgemensamma roller</a>
+            <a class="nav-link underavsnitt" href="#kap4-8-1">4.8.1 Rollutbildningsansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-8-2">4.8.2 Bidragsansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-8-3">4.8.3 Marknadsföringsansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-8-4">4.8.4 Lokalansvarig</a>
+            <a class="nav-link underavsnitt" href="#kap4-8-5">4.8.5 Dataskyddsombud</a>
+            <a class="nav-link underavsnitt" href="#kap4-8-6">4.8.6 Café och receptionsansvarig</a>
           </nav>
         </nav>
       </div><!-- end col-lg-3 order-lg-2 -->

--- a/src/foreningen/styrande-dokument/dkrr-005-policy-mot-diskriminering/index.php
+++ b/src/foreningen/styrande-dokument/dkrr-005-policy-mot-diskriminering/index.php
@@ -40,15 +40,15 @@
         <div>
     <h1><strong>Innehållsförteckning</strong></h1>
     </div>
-    <div class="section"><a href="#syfte">Syfte</a></div>
-    <div class="section"><a href="#mal">Mål</a></div>
-    <div class="section"><a href="#definitioner">Definitioner och begreppsförklaring</a></div>
-    <div class="subsection"><a href="#mobbing">Mobbing/kränkande behandling</a></div>
-    <div class="subsection"><a href="#trakasserier">Trakasserier/diskriminering</a></div>
-    <div class="subsection"><a href="#sexuella-trakasserier">Sexuella trakasserier</a></div>
-    <div class="section"><a href="#forebyggande">Förebyggande arbete</a></div>
-    <div class="section"><a href="#handlingsplan-individ">Handlingsplan individ</a></div>
-    <div class="section"><a href="#handlingsplan-styrelse">Handlingsplan styrelse</a></div>
+    <div class="kapitel"><a href="#syfte">Syfte</a></div>
+    <div class="kapitel"><a href="#mal">Mål</a></div>
+    <div class="kapitel"><a href="#definitioner">Definitioner och begreppsförklaring</a></div>
+    <div class="avsnitt"><a href="#mobbing">Mobbing/kränkande behandling</a></div>
+    <div class="avsnitt"><a href="#trakasserier">Trakasserier/diskriminering</a></div>
+    <div class="avsnitt"><a href="#sexuella-trakasserier">Sexuella trakasserier</a></div>
+    <div class="kapitel"><a href="#forebyggande">Förebyggande arbete</a></div>
+    <div class="kapitel"><a href="#handlingsplan-individ">Handlingsplan individ</a></div>
+    <div class="kapitel"><a href="#handlingsplan-styrelse">Handlingsplan styrelse</a></div>
     <p>&nbsp;</p>
         </div><!-- end document-toc -->
         
@@ -147,9 +147,9 @@
             <a class="nav-link" href="#syfte">Syfte</a>
             <a class="nav-link" href="#mal">Mål</a>
             <a class="nav-link" href="#definitioner">Definitioner och begreppsförklaring</a>
-            <a class="nav-link section" href="#mobbing">Mobbing/kränkande behandling</a>
-            <a class="nav-link section" href="#trakasserier">Trakasserier/diskriminering</a>
-            <a class="nav-link section" href="#sexuella-trakasserier">Sexuella trakasserier</a>
+            <a class="nav-link avsnitt" href="#mobbing">Mobbing/kränkande behandling</a>
+            <a class="nav-link avsnitt" href="#trakasserier">Trakasserier/diskriminering</a>
+            <a class="nav-link avsnitt" href="#sexuella-trakasserier">Sexuella trakasserier</a>
             <a class="nav-link" href="#forebyggande">Förebyggande arbete</a>
             <a class="nav-link" href="#handlingsplan-individ">Handlingsplan individ</a>
             <a class="nav-link" href="#handlingsplan-styrelse">Handlingsplan styrelse</a>

--- a/src/foreningen/styrande-dokument/dkrr-006-integritetspolicy/index.php
+++ b/src/foreningen/styrande-dokument/dkrr-006-integritetspolicy/index.php
@@ -40,13 +40,13 @@
         <div>
     <h1><strong>Innehållsförteckning</strong></h1>
     </div>
-    <div class="section"><a href="#parter">Parter och ansvar för behandlingen av dina personuppgifter</a></div>
-    <div class="section"><a href="#varfor">Varför behandlar vi dina personuppgifter?</a></div>
-    <div class="subsection"><a href="#delar">Vilka delar vi personuppgifter med?</a></div>
-    <div class="subsection"><a href="#grund">Vilken laglig grund har vi för personuppgiftsbehandling?</a></div>
-    <div class="subsection"><a href="#hur-lange">Hur länge sparar vi dina personuppgifter?</a></div>
-    <div class="subsection"><a href="#rattigheter">Vilka rättigheter har du?</a></div>
-    <div class="section"><a href="#veta-mera">Om du vill veta mera</a></div>
+    <div class="kapitel"><a href="#parter">Parter och ansvar för behandlingen av dina personuppgifter</a></div>
+    <div class="kapitel"><a href="#varfor">Varför behandlar vi dina personuppgifter?</a></div>
+    <div class="avsnitt"><a href="#delar">Vilka delar vi personuppgifter med?</a></div>
+    <div class="avsnitt"><a href="#grund">Vilken laglig grund har vi för personuppgiftsbehandling?</a></div>
+    <div class="avsnitt"><a href="#hur-lange">Hur länge sparar vi dina personuppgifter?</a></div>
+    <div class="avsnitt"><a href="#rattigheter">Vilka rättigheter har du?</a></div>
+    <div class="kapitel"><a href="#veta-mera">Om du vill veta mera</a></div>
     <p>&nbsp;</p>
         </div><!-- end document-toc -->
         
@@ -278,10 +278,10 @@
           <nav class="nav nav-pills flex-column">
             <a class="nav-link" href="#parter">Parter och ansvar för behandlingen av dina personuppgifter</a>
             <a class="nav-link" href="#varfor">Varför behandlar vi dina personuppgifter?</a>
-            <a class="nav-link section" href="#delar">Vilka delar vi personuppgifter med?</a>
-            <a class="nav-link section" href="#grund">Vilken laglig grund har vi för personuppgiftsbehandling?</a>
-            <a class="nav-link section" href="#hur-lange">Hur länge sparar vi dina personuppgifter?</a>
-            <a class="nav-link section" href="#rattigheter">Vilka rättigheter har du?</a>
+            <a class="nav-link avsnitt" href="#delar">Vilka delar vi personuppgifter med?</a>
+            <a class="nav-link avsnitt" href="#grund">Vilken laglig grund har vi för personuppgiftsbehandling?</a>
+            <a class="nav-link avsnitt" href="#hur-lange">Hur länge sparar vi dina personuppgifter?</a>
+            <a class="nav-link avsnitt" href="#rattigheter">Vilka rättigheter har du?</a>
             <a class="nav-link" href="#veta-mera">Om du vill veta mera</a>
           </nav>
         </nav>

--- a/src/foreningen/styrande-dokument/dokument.css
+++ b/src/foreningen/styrande-dokument/dokument.css
@@ -6,15 +6,14 @@ div.kapitel {
   font-weight: bold;
 }
 
-/* Intentering for section (t.ex. 1.1, 1.2, etc) */
+/* TOC - Intentering för avsnitt (t.ex. 1.1, 1.2, etc) */
 div.avsnitt,
-div.section,
 div.paragraf {
   padding-left: 4em;
 }
 
-/* Intentering for subsection (t.ex. 4.4.1, 4.4.2, etc) */
-div.subsection {
+/* TOC - Intentering för underavsnitt (t.ex. 4.4.1, 4.4.2, etc) */
+div.underavsnitt {
   padding-left: 6em;
 }
 
@@ -27,8 +26,7 @@ h2.kapitel {
 }
 
 h3.avsnitt,
-h3.paragraf,
-h3.section {
+h3.paragraf {
   font-weight: bold;
   margin-top: 1.5em;
   margin-bottom: 0.5em;
@@ -165,14 +163,15 @@ table.arshjul-table th,
   background-color: var(--bs-tertiary-bg, #e9ecef);
 }
 
-/* Indent sections (1.1, 1.2, etc) */
-.document-scrollspy-nav .nav-link.section {
+/* TOC - Indentering för avsnitt / paragraf (1.1, 1.2, etc) */
+.document-scrollspy-nav .nav-link.avsnitt,
+.document-scrollspy-nav .nav-link.paragraf {
   padding-left: 1.5rem;
   font-size: 0.7rem;
 }
 
-/* Indent subsections (4.4.1, 4.4.2, etc) */
-.document-scrollspy-nav .nav-link.subsection {
+/* TOC - Indentering för underavsnitt (4.4.1, 4.4.2, etc) */
+.document-scrollspy-nav .nav-link.underavsnitt {
   padding-left: 3rem;
   font-size: 0.6rem;
 }


### PR DESCRIPTION
This pull request standardizes the class names used for navigation links in the tables of contents across several styrande dokument (governing documents) pages. The main change is replacing the more generic class name `section` with more specific names (`avsnitt` or `paragraf`) depending on the document structure, improving clarity and consistency in the markup.

**Navigation class name standardization:**

* In `dkrr-001-verksamhetsbeskrivning/index.php` and `dkrr-002-arshjul-och-arbetsprocesser/index.php`, all navigation links for subsections now use the class `avsnitt` instead of `section`. [[1]](diffhunk://#diff-b604c82ec020bb2ef72ea4638e7f44613d6318271c356eefaedf1732d35ef6ccL842-R900) [[2]](diffhunk://#diff-26dcee641d9c03f216198f3fcf0372eee0dda9d9f31375bb3b4c672512b7b794L782-R797)
* In `dkrr-003-stadgar/index.php`, all navigation links for paragraphs now use the class `paragraf` instead of `section`.